### PR TITLE
[In progress] Coq 8.5

### DIFF
--- a/src/Common/Equality.v
+++ b/src/Common/Equality.v
@@ -1,6 +1,7 @@
 Require Import Coq.Lists.List.
 
 Set Implicit Arguments.
+Set Asymmetric Patterns.
 Local Close Scope nat_scope.
 
 Section sigT.

--- a/src/Common/Wf.v
+++ b/src/Common/Wf.v
@@ -2,6 +2,7 @@
 Require Import Coq.Setoids.Setoid Coq.Program.Program Coq.Program.Wf Coq.Arith.Wf_nat.
 
 Set Implicit Arguments.
+Set Asymmetric Patterns.
 
 Section wf.
   Section wf_prod.

--- a/src/Parsers/BooleanRecognizer.v
+++ b/src/Parsers/BooleanRecognizer.v
@@ -8,6 +8,7 @@ Require Import ParsingParses.Parsers.Splitters.RDPList ParsingParses.Parsers.Spl
 Require Import ParsingParses.Common ParsingParses.Common.Wf.
 
 Set Implicit Arguments.
+Set Asymmetric Patterns.
 Local Open Scope string_like_scope.
 
 (** TODO: Allow stubbing out of individual sub-parse methods *)

--- a/src/Parsers/ContextFreeGrammarProperties.v
+++ b/src/Parsers/ContextFreeGrammarProperties.v
@@ -3,6 +3,7 @@ Require Import ParsingParses.Parsers.StringLike ParsingParses.Parsers.ContextFre
 Require Import Coq.Classes.RelationClasses.
 
 Set Implicit Arguments.
+Set Asymmetric Patterns.
 
 Delimit Scope string_like_scope with string_like.
 

--- a/src/Parsers/DependentlyTyped.v
+++ b/src/Parsers/DependentlyTyped.v
@@ -273,7 +273,7 @@ Section recursive_descent_parser.
             Proof.
               destruct splits as [ | [s1 s2] splits ]; simpl in *.
               { exact (inr (H_prod_split' pf tt)). }
-              { refine (let Hs1 := _ in
+              { simple refine (let Hs1 := _ in
                         let Hs2 := _ in
                         match (@parse_item str0
                                            valid

--- a/src/Parsers/DependentlyTypedMinimalOfParse.v
+++ b/src/Parsers/DependentlyTypedMinimalOfParse.v
@@ -6,6 +6,7 @@ Require Import ParsingParses.Parsers.WellFoundedParse ParsingParses.Parsers.Cont
 Require Import ParsingParses.Common ParsingParses.Common.Wf ParsingParses.Common.Le.
 
 Set Implicit Arguments.
+Set Asymmetric Patterns.
 
 Local Open Scope string_like_scope.
 

--- a/src/Parsers/DependentlyTypedOption.v
+++ b/src/Parsers/DependentlyTypedOption.v
@@ -6,6 +6,7 @@ Require Import ParsingParses.Parsers.DependentlyTyped ParsingParses.Parsers.Base
 Require Import ParsingParses.Common ParsingParses.Common.Equality.
 
 Set Implicit Arguments.
+Set Asymmetric Patterns.
 
 Local Open Scope string_like_scope.
 

--- a/src/Parsers/DependentlyTypedSum.v
+++ b/src/Parsers/DependentlyTypedSum.v
@@ -5,6 +5,7 @@ Require Import ParsingParses.Parsers.WellFoundedParse ParsingParses.Parsers.Cont
 Require Import ParsingParses.Common ParsingParses.Common.Wf ParsingParses.Common.Le ParsingParses.Common.Equality.
 
 Set Implicit Arguments.
+Set Asymmetric Patterns.
 
 Local Close Scope nat_scope.
 Local Open Scope string_like_scope.

--- a/src/Parsers/Grammars/ABStar.v
+++ b/src/Parsers/Grammars/ABStar.v
@@ -33,7 +33,7 @@ Section tests.
   Example ab_star_parses_ab : parse_of_grammar string_stringlike "ab"%string ab_star_grammar.
   Proof.
     hnf; simpl.
-    constructor (constructor); simpl.
+    constructor; constructor; simpl.
     apply ParseProductionCons with (str := "a"%string) (strs := "b"%string).
     { refine (ParseTerminal _ _ _). }
     { apply ParseProductionCons with (str := "b"%string) (strs := ""%string).
@@ -45,7 +45,7 @@ Section tests.
   Example ab_star_parses_abab : parse_of_grammar string_stringlike "abab"%string ab_star_grammar.
   Proof.
     hnf; simpl.
-    constructor (constructor); simpl.
+    constructor; constructor; simpl.
     apply ParseProductionCons with (str := "a"%string) (strs := "bab"%string).
     { refine (ParseTerminal _ _ _). }
     { apply ParseProductionCons with (str := "b"%string) (strs := "ab"%string).

--- a/src/Parsers/Grammars/ExpressionNumPlus.v
+++ b/src/Parsers/Grammars/ExpressionNumPlus.v
@@ -26,7 +26,7 @@ Section tests.
                  | refine (ParseTerminal _ _ _)
                  | refine (ParseNonTerminal _ _)
                  | progress simpl
-                 | solve [ constructor (solve [ fin ]) ] ].
+                 | solve [ constructor; solve [ fin ] ] ].
 
   Example plus_expr_parses_1 : parse_of_grammar string_stringlike "1+2+3+4+5"%string plus_expr_grammar.
   Proof.

--- a/src/Parsers/Grammars/ExpressionNumPlusParen.v
+++ b/src/Parsers/Grammars/ExpressionNumPlusParen.v
@@ -28,7 +28,7 @@ Section tests.
                  | refine (ParseTerminal _ _ _)
                  | refine (ParseNonTerminal _ _)
                  | progress simpl
-                 | solve [ constructor (solve [ fin ]) ] ].
+                 | solve [ constructor; solve [ fin ] ] ].
 
   Example plus_expr_parses_1 : parse_of_grammar string_stringlike "1+(2+3)+4+5"%string plus_expr_grammar.
   Proof.

--- a/src/Parsers/Grammars/ExpressionParen.v
+++ b/src/Parsers/Grammars/ExpressionParen.v
@@ -27,7 +27,7 @@ Section tests.
                  | refine (ParseTerminal _ _ _)
                  | refine (ParseNonTerminal _ _)
                  | progress simpl
-                 | solve [ constructor (solve [ fin ]) ] ].
+                 | solve [ constructor; solve [ fin ] ] ].
 
   Example paren_expr_parses_1 : parse_of_grammar string_stringlike "(((123)))"%string paren_expr_grammar.
   Proof.

--- a/src/Parsers/MinimalParseOfParse.v
+++ b/src/Parsers/MinimalParseOfParse.v
@@ -8,6 +8,7 @@ Require Export ParsingParses.Parsers.MinimalParse.
 Require Import ParsingParses.Common ParsingParses.Common.Wf.
 
 Set Implicit Arguments.
+Set Asymmetric Patterns.
 Local Open Scope string_like_scope.
 
 Local Notation "f ∘ g" := (fun x => f (g x)).

--- a/src/Parsers/MinimalParseOfParse.v
+++ b/src/Parsers/MinimalParseOfParse.v
@@ -111,7 +111,7 @@ Section cfg.
     : minimal_parse_of_nonterminal (String := String) (G := G) str0 valid' str nonterminal.
     Proof.
       destruct p.
-      { constructor (assumption). }
+      { constructor; assumption. }
       { exfalso; clear -Hlt; omega. }
     Defined.
 
@@ -123,7 +123,7 @@ Section cfg.
     Proof.
       destruct p as [p|p].
       { constructor. }
-      { constructor (eapply contract_minimal_parse_of_nonterminal_lt; eassumption). }
+      { constructor; eapply contract_minimal_parse_of_nonterminal_lt; eassumption. }
     Defined.
 
     Definition contract_minimal_parse_of_production_lt
@@ -152,8 +152,8 @@ Section cfg.
     : minimal_parse_of (String := String) (G := G) str0 valid' str pats.
     Proof.
       induction p.
-      { constructor (eapply contract_minimal_parse_of_production_lt; eassumption). }
-      { constructor (eapply IHp; assumption). }
+      { constructor; eapply contract_minimal_parse_of_production_lt; eassumption. }
+      { constructor; eapply IHp; assumption. }
     Defined.
 
     Section contract_eq.

--- a/src/Parsers/Splitters/FirstChar.v
+++ b/src/Parsers/Splitters/FirstChar.v
@@ -16,6 +16,7 @@ Require Import ParsingParses.Parsers.ContextFreeGrammarNotations.
 Require Import ParsingParses.Parsers.Grammars.ABStar.
 
 Set Implicit Arguments.
+Set Asymmetric Patterns.
 Local Open Scope string_scope.
 Local Open Scope string_like_scope.
 

--- a/src/Parsers/Splitters/OnlyOneNonterminal.v
+++ b/src/Parsers/Splitters/OnlyOneNonterminal.v
@@ -16,6 +16,7 @@ Require Import ParsingParses.Parsers.ContextFreeGrammarNotations.
 Require Import ParsingParses.Parsers.Grammars.ABStar.
 
 Set Implicit Arguments.
+Set Asymmetric Patterns.
 Local Open Scope type_scope.
 Local Open Scope string_scope.
 Local Open Scope string_like_scope.

--- a/src/Parsers/WellFoundedParse.v
+++ b/src/Parsers/WellFoundedParse.v
@@ -2,6 +2,7 @@
 Require Import Coq.Strings.String Coq.Lists.List Coq.Program.Program Coq.Program.Wf Coq.Arith.Wf_nat Coq.Relations.Relation_Definitions.
 Require Import ParsingParses.Parsers.ContextFreeGrammar.
 
+Set Asymmetric Patterns.
 Section rel.
   Context {CharType} {String : string_like CharType} {G : grammar CharType}.
 


### PR DESCRIPTION
I'm hoping to extend this to a formalization of Range Concatenation Grammars, and so decided to try and update it to Coq 8.5pl3. However, I've run into an issue in `src/Parsers/DependentlyTypedSum.v`:
```
The term "pf" has type "?T3@{x:={| string_val := str; state_val := None |}}"
while it is expected to have type "tts str ≤s ?s" (cannot instantiate
"?T3" because "str" is not in its scope).
```

I suspect this is due to the following note in the Coq CHANGES file:

> - The guard condition for fixpoints is now a bit stricter. Propagation of subterm value through pattern matching is restricted according to the return predicate. Restores compatibility of Coq's logic with the   propositional extensionality axiom. May create incompatibilities in recursive programs heavily using dependent types.

Any ideas?

Full error:
```
COQC src/Parsers/DependentlyTypedSum.v
File "./src/Parsers/DependentlyTypedSum.v", line 240, characters 96-98:
Error:
In environment
CharType : Type
String : string_like CharType
G : grammar CharType
leaf_predata : parser_computational_predataT
leaf_methods' : parser_computational_dataT'
leaf_stypes' : parser_dependent_types_success_dataT'
leaf_ftypes' : parser_dependent_types_failure_dataT'
leaf_strdata : parser_computational_strdataT
leaf_extra_success_data : parser_dependent_types_extra_success_dataT'
leaf_extra_failure_data : parser_dependent_types_extra_failure_dataT'
remove_nonterminal_1 : forall (ls : nonterminals_listT) (ps ps' : string),
                       is_valid_nonterminal (remove_nonterminal ls ps) ps' =
                       true -> is_valid_nonterminal ls ps' = true
remove_nonterminal_2 : forall (ls : nonterminals_listT) (ps ps' : string),
                       is_valid_nonterminal (remove_nonterminal ls ps) ps' =
                       false <->
                       is_valid_nonterminal ls ps' = false \/ ps = ps'
top_split_stateT : String ->
                   nonterminals_listT ->
                   any_grammar CharType -> String -> Type
top_methods' : parser_computational_dataT'
top_prestrdata : parser_computational_prestrdataT
lift_failure_cross :
forall (x : String) (x0 : nonterminals_listT) (x1 : string)
  (x2 : StringWithSplitState String
          (split_stateT x x0 (NonTerminal CharType x1))),
lower_nonterminal_state (state_val (lift_StringWithSplitState x2 Some)) =
None ->
T_nonterminal_failure x x0 x1 (tts (lift_StringWithSplitState x2 Some)) ->
T_item_failure x x0 (NonTerminal CharType x1)
  (lift_StringWithSplitState x2 Some)
parse_terminal_failure_cross :
forall (x : String) (x0 : nonterminals_listT) (x1 : CharType)
  (x2 : StringWithSplitState String (split_stateT x x0 (Terminal x1))),
([[x1]] =s lift_StringWithSplitState x2 Some) = false ->
T_item_failure x x0 (Terminal x1) (lift_StringWithSplitState x2 Some)
parse_empty_failure_cross :
forall (x : String) (x0 : nonterminals_listT)
  (x1 : StringWithSplitState String (split_stateT x x0 [])),
lift_StringWithSplitState x1 Some ≤s x ->
(lift_StringWithSplitState x1 Some =s Empty String) = false ->
T_production_failure x x0 [] (lift_StringWithSplitState x1 Some)
fail_parse_nil_productions_cross :
forall (x : String) (x0 : nonterminals_listT)
  (x1 : StringWithSplitState String (split_stateT x x0 [])),
T_productions_failure x x0 [] (lift_StringWithSplitState x1 Some)
lift_prods_failure_cross :
forall (x : String) (x0 : nonterminals_listT) (x1 : production CharType)
  (x2 : list (production CharType))
  (x3 : StringWithSplitState String (split_stateT x x0 (x1 :: x2))),
lower_string_head (state_val (lift_StringWithSplitState x3 Some)) = None ->
T_production_failure x x0 x1 (tts (lift_StringWithSplitState x3 Some)) ->
lower_string_tail (state_val (lift_StringWithSplitState x3 Some)) = None ->
T_productions_failure x x0 x2 (tts (lift_StringWithSplitState x3 Some)) ->
T_productions_failure x x0 (x1 :: x2) (lift_StringWithSplitState x3 Some)
H_prod_split_cross :
forall (str0 : String) (valid : nonterminals_listT)
  (it : item CharType) (its : list (item CharType))
  (str : StringWithSplitState String
           (top_split_stateT str0 valid (it :: its))),
str ≤s str0 -> split_string_for_production str0 valid it its (eta str) <> []
lift_parse_nonterminal_failure_lt_cross : ?T
lift_parse_nonterminal_failure_eq_cross : ?T0
elim_parse_nonterminal_failure_init_cross : ?T1
elim_parse_nonterminal_failure_cross : ?T2
str0 : String
valid : nonterminals_listT
it : item CharType
its : production CharType
str : String
pf : ?T3@{x:={| string_val := str; state_val := None |}}
The term "pf" has type "?T3@{x:={| string_val := str; state_val := None |}}"
while it is expected to have type "tts str ≤s ?s" (cannot instantiate
"?T3" because "str" is not in its scope: available arguments are
"CharType" "String" "G" "leaf_predata" "leaf_methods'"
"leaf_stypes'" "leaf_ftypes'" "leaf_strdata" "leaf_extra_success_data"
"leaf_extra_failure_data" "remove_nonterminal_1" "remove_nonterminal_2"
"top_split_stateT" "top_methods'" "top_prestrdata"
"lift_failure_cross" "parse_terminal_failure_cross"
"parse_empty_failure_cross" "fail_parse_nil_productions_cross"
"lift_prods_failure_cross" "H_prod_split_cross"
"lift_parse_nonterminal_failure_lt_cross"
"lift_parse_nonterminal_failure_eq_cross"
"elim_parse_nonterminal_failure_init_cross"
"elim_parse_nonterminal_failure_cross" "str0" "valid"
"it" "its" "{| string_val := str; state_val := None |}").
make: *** [Makefile.coq:313: src/Parsers/DependentlyTypedSum.vo] Error 1
```